### PR TITLE
Changed this {{Overview}} to {{{Overview}}}

### DIFF
--- a/item-added.handlebars
+++ b/item-added.handlebars
@@ -27,7 +27,7 @@
 
             "description": "
             {{~#if_exist Overview~}}
-                > {{Overview}}\n\n
+                > {{{Overview}}}\n\n
             {{~/if_exist~}}
 
             {{~#if_exist ServerUrl~}}


### PR DESCRIPTION
Because it breaks the template when the overview has special characters like quotes and such. This took me 3 hours to fix this simple problem lol.
reference: https://handlebarsjs.com/guide/#html-escaping